### PR TITLE
Add fan-out support for multiple NGINX+ Edge Load-Balancers

### DIFF
--- a/deployment/nkl-configmap.yaml
+++ b/deployment/nkl-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  nginx-hosts:
+    "http://10.1.1.4:9000/api,http://10.1.1.5:9000/api"
+metadata:
+  name: nkl-config
+  namespace: nkl

--- a/deployment/nkl-deployment.yaml
+++ b/deployment/nkl-deployment.yaml
@@ -3,22 +3,22 @@ kind: Deployment
 metadata:
   name: nkl-deployment
   labels:
-    app: nec
+    app: nkl
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nec
+      app: nkl
   template:
     metadata:
       labels:
-        app: nec
+        app: nkl
     spec:
       containers:
         - name: nginx-k8s-edge-controller
           env:
             - name: NGINX_PLUS_HOST
-              value: "http://192.168.1.109:9000/api"
+              value: "http://10.1.1.4:9000/api"
           image: ciroque/nginx-k8s-edge-controller:latest
           imagePullPolicy: Always
       serviceAccountName: nginx-k8s-edge-controller

--- a/deployment/nkl-namespace.yaml
+++ b/deployment/nkl-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nkl
+  labels:
+    name: nkl

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -5,21 +5,131 @@
 package config
 
 import (
-	"errors"
-	"os"
+	"context"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"strings"
+)
+
+const (
+	ConfigMapsNamespace = "nkl"
+	ResyncPeriod        = 0
 )
 
 type Settings struct {
-	NginxPlusHost string
+	ctx                      context.Context
+	NginxPlusHosts           []string
+	k8sClient                *kubernetes.Clientset
+	informer                 cache.SharedInformer
+	eventHandlerRegistration cache.ResourceEventHandlerRegistration
 }
 
-func NewSettings() (*Settings, error) {
+func NewSettings(ctx context.Context, k8sClient *kubernetes.Clientset) (*Settings, error) {
 	config := new(Settings)
 
-	config.NginxPlusHost = os.Getenv("NGINX_PLUS_HOST")
-	if config.NginxPlusHost == "" {
-		return nil, errors.New("the NGINX_PLUS_HOST variable is not defined. This is required")
-	}
+	config.k8sClient = k8sClient
+	config.ctx = ctx
 
 	return config, nil
+}
+
+func (s *Settings) Initialize() error {
+	logrus.Info("Settings::Initialize")
+
+	var err error
+
+	informer, err := s.buildInformer()
+	if err != nil {
+		return fmt.Errorf(`error occurred building ConfigMap informer: %w`, err)
+	}
+
+	s.informer = informer
+
+	err = s.initializeEventListeners()
+	if err != nil {
+		return fmt.Errorf(`error occurred initializing event listeners: %w`, err)
+	}
+
+	return nil
+}
+
+func (s *Settings) Run() {
+	logrus.Debug("Settings::Run")
+
+	defer utilruntime.HandleCrash()
+
+	go s.informer.Run(s.ctx.Done())
+
+	<-s.ctx.Done()
+}
+
+func (s *Settings) buildInformer() (cache.SharedInformer, error) {
+	options := informers.WithNamespace(ConfigMapsNamespace)
+	factory := informers.NewSharedInformerFactoryWithOptions(s.k8sClient, ResyncPeriod, options)
+	informer := factory.Core().V1().ConfigMaps().Informer()
+
+	return informer, nil
+}
+
+func (s *Settings) initializeEventListeners() error {
+	logrus.Debug("Settings::initializeEventListeners")
+
+	var err error
+
+	handlers := cache.ResourceEventHandlerFuncs{
+		AddFunc:    s.handleAddEvent,
+		UpdateFunc: s.handleUpdateEvent,
+		DeleteFunc: s.handleDeleteEvent,
+	}
+
+	s.eventHandlerRegistration, err = s.informer.AddEventHandler(handlers)
+	if err != nil {
+		return fmt.Errorf(`error occurred registering event handlers: %w`, err)
+	}
+
+	return nil
+}
+
+func (s *Settings) handleAddEvent(obj interface{}) {
+	logrus.Debug("Settings::handleAddEvent")
+
+	s.handleUpdateEvent(obj, nil)
+}
+
+func (s *Settings) handleDeleteEvent(_ interface{}) {
+	logrus.Debug("Settings::handleDeleteEvent")
+
+	s.updateHosts([]string{})
+}
+
+func (s *Settings) handleUpdateEvent(obj interface{}, _ interface{}) {
+	logrus.Debug("Settings::handleUpdateEvent")
+
+	configMap, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		logrus.Errorf("Settings::handleUpdateEvent: could not convert obj to ConfigMap")
+		return
+	}
+
+	hosts, found := configMap.Data["nginx-hosts"]
+	if !found {
+		logrus.Errorf("Settings::handleUpdateEvent: nginx-hosts key not found in ConfigMap")
+		return
+	}
+
+	newHosts := s.parseHosts(hosts)
+	s.updateHosts(newHosts)
+}
+
+func (s *Settings) parseHosts(hosts string) []string {
+	return strings.Split(hosts, ",")
+}
+
+func (s *Settings) updateHosts(hosts []string) {
+	s.NginxPlusHosts = hosts
 }

--- a/internal/core/events.go
+++ b/internal/core/events.go
@@ -21,6 +21,8 @@ type Event struct {
 }
 
 type ServerUpdateEvent struct {
+	Id           string
+	NginxHost    string
 	Type         EventType
 	UpstreamName string
 	Servers      []nginxClient.StreamUpstreamServer
@@ -42,6 +44,16 @@ func NewServerUpdateEvent(eventType EventType, upstreamName string, servers []ng
 		Type:         eventType,
 		UpstreamName: upstreamName,
 		Servers:      servers,
+	}
+}
+
+func ServerUpdateEventWithIdAndHost(event *ServerUpdateEvent, id string, nginxHost string) *ServerUpdateEvent {
+	return &ServerUpdateEvent{
+		Id:           id,
+		NginxHost:    nginxHost,
+		Type:         event.Type,
+		UpstreamName: event.UpstreamName,
+		Servers:      event.Servers,
 	}
 }
 

--- a/internal/synchronization/rand.go
+++ b/internal/synchronization/rand.go
@@ -1,0 +1,31 @@
+// Copyright 2023 f5 Inc. All rights reserved.
+// Use of this source code is governed by the Apache
+// license that can be found in the LICENSE file.
+
+package synchronization
+
+import (
+	"math/rand"
+	"time"
+)
+
+var charset = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+var number = []byte("0123456789")
+var alphaNumeric = append(charset, number...)
+
+// RandomString where n is the length of random string we want to generate
+func RandomString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		// randomly select 1 character from given charset
+		b[i] = alphaNumeric[rand.Intn(len(alphaNumeric))]
+	}
+	return string(b)
+}
+
+func RandomMilliseconds(min, max int) time.Duration {
+	randomizer := rand.New(rand.NewSource(time.Now().UnixNano()))
+	random := randomizer.Intn(max-min) + min
+
+	return time.Millisecond * time.Duration(random)
+}

--- a/k8s/RBAC/ClusterRole.yaml
+++ b/k8s/RBAC/ClusterRole.yaml
@@ -5,5 +5,5 @@ metadata:
 rules:
   - apiGroups:
         - ""
-    resources: ["services", "nodes"]
+    resources: ["services", "nodes", "configmaps"]
     verbs: ["get", "watch", "list"]


### PR DESCRIPTION
Settings using Informer instead of Watch

Closes #4 

### Proposed changes

This change adds support for maintaining multiple NGINX+ Edge Load Balancers. Also, the environment variable configuration has been replaced with a ConfigMap so updates can be performed on the fly without restarting or redeploying the controller.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/CHANGELOG.md))
