### PR TITLE
Clean up deployment

### DIFF
--- a/deployment/nkl-deployment.yaml
+++ b/deployment/nkl-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nkl-deployment
+  namespace: nkl
   labels:
     app: nkl
 spec:
@@ -16,9 +17,6 @@ spec:
     spec:
       containers:
         - name: nginx-k8s-edge-controller
-          env:
-            - name: NGINX_PLUS_HOST
-              value: "http://10.1.1.4:9000/api"
           image: ciroque/nginx-k8s-edge-controller:latest
           imagePullPolicy: Always
           ports:


### PR DESCRIPTION
- Remove old environment variable
- Deploy to nkl namespace

### Proposed changes

There was cruft in the deployment from when the implementation could handle only one NGINX+ Edge host. That configuration has been moved into a ConfigMap, this removes the configuration from the deployment.

Also, the deployment was going into the default namespace, the deployment now uses the `nkl` namespace.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/CHANGELOG.md))
