### PR TITLE
Move constant to configuration

### DIFF
--- a/internal/configuration/settings.go
+++ b/internal/configuration/settings.go
@@ -20,6 +20,7 @@ import (
 const (
 	ConfigMapsNamespace = "nkl"
 	ResyncPeriod        = 0
+	NklPrefix           = ConfigMapsNamespace + "-"
 )
 
 type WorkQueueSettings struct {

--- a/internal/translation/translator.go
+++ b/internal/translation/translator.go
@@ -6,14 +6,13 @@ package translation
 
 import (
 	"fmt"
+	"github.com/nginxinc/kubernetes-nginx-ingress/internal/configuration"
 	"github.com/nginxinc/kubernetes-nginx-ingress/internal/core"
 	nginxClient "github.com/nginxinc/nginx-plus-go-client/client"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"strings"
 )
-
-const NklPrefix = "nkl-"
 
 func Translate(event *core.Event) (core.ServerUpdateEvents, error) {
 	logrus.Debug("Translate::Translate")
@@ -27,7 +26,7 @@ func filterPorts(ports []v1.ServicePort) []v1.ServicePort {
 	var portsOfInterest []v1.ServicePort
 
 	for _, port := range ports {
-		if strings.HasPrefix(port.Name, NklPrefix) {
+		if strings.HasPrefix(port.Name, configuration.NklPrefix) {
 			portsOfInterest = append(portsOfInterest, port)
 		}
 	}

--- a/internal/translation/translator_test.go
+++ b/internal/translation/translator_test.go
@@ -6,6 +6,7 @@ package translation
 
 import (
 	"fmt"
+	"github.com/nginxinc/kubernetes-nginx-ingress/internal/configuration"
 	"github.com/nginxinc/kubernetes-nginx-ingress/internal/core"
 	v1 "k8s.io/api/core/v1"
 	"math/rand"
@@ -653,7 +654,7 @@ func generateUpdatablePorts(portCount int, updatableCount int) []v1.ServicePort 
 	nonupdatable := make([]string, portCount-updatableCount)
 
 	for i := range updatable {
-		updatable[i] = NklPrefix
+		updatable[i] = configuration.NklPrefix
 	}
 
 	for j := range nonupdatable {


### PR DESCRIPTION
### Proposed changes

This constant was missed in the Great Configuration Migration of March 9th. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-k8s-edge-controller/blob/main/CHANGELOG.md))
