### PR TITLE
Rename arguments for clarity and ensure correct usage

### DIFF
--- a/internal/certification/certificates.go
+++ b/internal/certification/certificates.go
@@ -176,7 +176,7 @@ func (c *Certificates) handleDeleteEvent(obj interface{}) {
 	logrus.Debugf("Certificates::handleDeleteEvent: certificates (%d)", len(c.Certificates))
 }
 
-func (c *Certificates) handleUpdateEvent(oldValue interface{}, newValue interface{}) {
+func (c *Certificates) handleUpdateEvent(_ interface{}, newValue interface{}) {
 	logrus.Debug("Certificates::handleUpdateEvent")
 
 	secret, ok := newValue.(*corev1.Secret)

--- a/internal/configuration/settings.go
+++ b/internal/configuration/settings.go
@@ -266,10 +266,10 @@ func (s *Settings) handleDeleteEvent(obj interface{}) {
 	}
 }
 
-func (s *Settings) handleUpdateEvent(_ interface{}, obj interface{}) {
+func (s *Settings) handleUpdateEvent(_ interface{}, newValue interface{}) {
 	logrus.Debug("Settings::handleUpdateEvent")
 
-	configMap, yes := isOurConfig(obj)
+	configMap, yes := isOurConfig(newValue)
 	if !yes {
 		return
 	}


### PR DESCRIPTION
### Proposed changes

There was a bug in argument usage that had already been fixed. This is a simple rename to help make the arguments obvious.

Closes #131 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CHANGELOG.md))
