### PR TITLE
Remove the development feature warning

### DIFF
--- a/docs/tls/README.md
+++ b/docs/tls/README.md
@@ -1,8 +1,5 @@
 # Securing communication between NLK and NGINX Plus with TLS / mTLS
 
-> [!WARNING]
-> THIS FEATURE IS IN DEVELOPMENT. THIS NOTICE WILL BE REMOVED WHEN THE IMPLEMENTATION IS COMPLETE.  
-
 This document describes how to configure TLS / mTLS to secure communication between NLK and NGINX Plus.
 
 For development and test environments, using secure communication may not be necessary; however, in production environments


### PR DESCRIPTION
### Proposed changes

There was warning verbiage in the documentation while the TLS implementation was being developed. This removes that warning.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CHANGELOG.md))
