### PR TITLE
Use a nicer command to tail pod logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![CI](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/actions/workflows/build-test.yml/badge.svg)](https://github.com/nginxinc/nginx-loadbalancer-kubernetess/actions/workflows/build-test.yml) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/nginxinc/nginx-loadbalancer-kubernetes)](https://goreportcard.com/report/github.com/nginxinc/nginx-loadbalancer-kubernetes) 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
-[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/nginxinc/nginx-loadbalancer-kubernetes?logo=github&sort=semver)](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/releases/latest) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/nginxinc/nginx-loadbalancer-kubernetes?logo=go) 
+[![CI](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/actions/workflows/build-test.yml/badge.svg)](https://github.com/nginxinc/nginx-loadbalancer-kubernetess/actions/workflows/build-test.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nginxinc/nginx-loadbalancer-kubernetes)](https://goreportcard.com/report/github.com/nginxinc/nginx-loadbalancer-kubernetes)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/nginxinc/nginx-loadbalancer-kubernetes?logo=github&sort=semver)](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/releases/latest) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/nginxinc/nginx-loadbalancer-kubernetes?logo=go)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/nginxinc/nginx-loadbalancer-kubernetes/badge)](https://api.securityscorecards.dev/projects/github.com/nginxinc/nginx-loadbalancer-kubernetes)
 [![CodeQL](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/workflows/codeql.yml/badge.svg?branch=main&event=push)](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/actions/codeql.yml)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fnginxinc%2Fnginx-loadbalancer-kubernetes.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fnginxinc%2Fnginx-loadbalancer-kubernetes?ref=badge_shield)
@@ -44,7 +44,7 @@ NLK provides a simple, easy-to-manage way to automate load balancing for your Ku
 
 NLK installs easily, has a small footprint, and is easy to configure and manage.
 
-NLK does not require learning a custom object model, you only have to understand NGINX configuration to get the most out of this solution. 
+NLK does not require learning a custom object model, you only have to understand NGINX configuration to get the most out of this solution.
 There is thorough documentation available with the specifics in the `docs/` directory.
 
 ### What does NLK do?
@@ -53,15 +53,15 @@ tl;dr:
 
 _**NLK is a Kubernetes controller that monitors Services and Nodes in your cluster, and then sends API calls to an external NGINX Plus server to manage NGINX Plus Upstream servers automatically.**_
 
-That's all well and good, but what does it mean? Kubernetes clusters require some tooling to handling routing traffic from the outside world (e.g.: the Internet, corporate network, etc.) to the cluster. 
+That's all well and good, but what does it mean? Kubernetes clusters require some tooling to handling routing traffic from the outside world (e.g.: the Internet, corporate network, etc.) to the cluster.
 This is typically done with a load balancer. The load balancer is responsible for routing traffic to the appropriate worker node which then forwards the traffic to the appropriate Service / Pod.
 
-If you are using a hosted Kubernetes solution -- Digital Ocean, AWS, Azure, etc. -- you can use the cloud provider's load balancer service. Those services will create a load balancer for you. 
+If you are using a hosted Kubernetes solution -- Digital Ocean, AWS, Azure, etc. -- you can use the cloud provider's load balancer service. Those services will create a load balancer for you.
 You can use the cloud provider's API to manage the load balancer, or you can use the cloud provider's web console.
 
 If you are running Kubernetes on-premise and will need to manage your own load balancer, NLK can help.
 
-NLK itself does not perform load balancing. Rather, NLK allows you to manage Service resources within your cluster to update your load balancers, with tooling you are most likely already using. 
+NLK itself does not perform load balancing. Rather, NLK allows you to manage Service resources within your cluster to update your load balancers, with tooling you are most likely already using.
 
 <img src="docs/media/nlk-blog-diagram-v1.png" width="768" />
 
@@ -70,7 +70,7 @@ NLK itself does not perform load balancing. Rather, NLK allows you to manage Ser
 There are few bits of administrivia to get out of the way before you can start leveraging NLK for your load balancing needs.
 
 As noted above, NLK is intended for when you have one or more Kubernetes clusters running on-premise. In addition to this,
-you need to have at least one NGINX Plus host running outside your cluster (Please refer to the [Roadmap](#Roadmap) for information about other load balancer servers). 
+you need to have at least one NGINX Plus host running outside your cluster (Please refer to the [Roadmap](#Roadmap) for information about other load balancer servers).
 
 ### Deployment
 
@@ -92,20 +92,20 @@ You will need to update this ConfigMap to reflect the NGINX Plus hosts you wish 
 
 If you were to deploy the ConfigMap and start NLK without updating the `nginx-hosts` value, don't fear; the ConfigMap resource is monitored for changes and NLK will update the NGINX Plus hosts accordingly when the resource is changed, no restart required.
 
-There is an extensive [Installation Reference](docs/README.md) available in the `docs/` directory. 
+There is an extensive [Installation Reference](docs/README.md) available in the `docs/` directory.
 Please refer to that for detailed instructions on how to deploy NLK and run a demo application.
 
 #### Versioning
 
-Versioning is a work in progress. The CI/CD pipeline is being developed and will be used to build and publish NLK images to the Container Registry. 
+Versioning is a work in progress. The CI/CD pipeline is being developed and will be used to build and publish NLK images to the Container Registry.
 Once in place, semantic versioning will be used for published images.
 
 #### Deployment Steps
 
-To get NLK up and running in ten steps or fewer, follow these instructions (NOTE, all the aforementioned prerequisites must be met for this to work). 
+To get NLK up and running in ten steps or fewer, follow these instructions (NOTE, all the aforementioned prerequisites must be met for this to work).
 There is a much more detailed [Installation Reference](docs/README.md) available in the `docs/` directory.
 
-1. Clone this repo (optional, you can simply copy the `deployments/` directory) 
+1. Clone this repo (optional, you can simply copy the `deployments/` directory)
 
 ```git clone git@github.com:nginxinc/nginx-loadbalancer-kubernetes.git```
 
@@ -127,35 +127,35 @@ There is a much more detailed [Installation Reference](docs/README.md) available
 
 6. Check the logs
 
-```kubectl -n nlk get pods | grep deployment | cut -f1 -d" "  | xargs kubectl logs -n nlk --follow $1```
+```kubectl -n nlk logs -f $(kubectl -n nlk get po -l "app=nlk" --no-headers -o custom-columns=":metadata.name")```
 
-At this point NLK should be up and running. Now would be a great time to go over to the [Installation Reference](docs/README.md) 
+At this point NLK should be up and running. Now would be a great time to go over to the [Installation Reference](docs/README.md)
 and follow the instructions to deploy a demo application.
 
 ### Monitoring
 
-Presently NLK includes a fair amount of logging. This is intended to be used for debugging purposes. 
+Presently NLK includes a fair amount of logging. This is intended to be used for debugging purposes.
 There are plans to add more robust monitoring and alerting in the future.
 
 As a rule, we support the use of [OpenTelemetry](https://opentelemetry.io/) for observability, and we will be adding support in the near future.
 
 ## Contributing
 
-Presently we are not accepting pull requests. However, we welcome your feedback and suggestions. 
+Presently we are not accepting pull requests. However, we welcome your feedback and suggestions.
 Please open an issue to let us know what you think!
 
 One way to contribute is to help us test NLK. We are looking for people to test NLK in a variety of environments.
 
-If you are curious about the implementation, you should certainly browse the code, but first you might wish to refer to the [design document](docs/DESIGN.md). 
+If you are curious about the implementation, you should certainly browse the code, but first you might wish to refer to the [design document](docs/DESIGN.md).
 Some of the design decisions are explained there.
 
 ## Roadmap
 
 While NLK was initially written specifically for NGINX Plus, we recognize there are other load-balancers that can be supported.
 
-To this end, NLK has been architected to be extensible to support other "Border Servers". 
-Border Servers are the term NLK uses to describe load-balancers, reverse proxies, etc. that run outside the cluster and handle 
-routing outside traffic to your cluster. 
+To this end, NLK has been architected to be extensible to support other "Border Servers".
+Border Servers are the term NLK uses to describe load-balancers, reverse proxies, etc. that run outside the cluster and handle
+routing outside traffic to your cluster.
 
 While we have identified a few potential targets, we are open to suggestions. Please open an issue to share your thoughts on potential implementations.
 


### PR DESCRIPTION
While what we have also works, labels is a nicer
way to select k8s objects.

```shell
nginx-loadbalancer-kubernetes $ kubectl -n nlk logs -f $(kubectl -n nlk get po -l "app=nlk" --no-headers -o custom-columns=":metadata.name")
time="2024-02-28T20:35:49Z" level=info msg="Settings::Initialize"
time="2024-02-28T20:35:49Z" level=info msg="Certificates::Initialize"
time="2024-02-28T20:35:49Z" level=info msg="Certificates::Run"
I0228 20:35:49.398213       1 shared_informer.go:273] Waiting for caches to sync for nlk-handler
I0228 20:35:49.500005       1 shared_informer.go:280] Caches are synced for nlk-handler
```

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CHANGELOG.md))
