### PR TITLE
Renames the control plane label

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The NGINX Loadbalancer for Kubernetes, or _NLK_, is a Kubernetes controller that
 
 ### What you will need
 
-- [ ] A Kubernetes cluster running on-premise.
+- [ ] A On-Premise Kubernetes cluster running version 1.24 or higher.
 - [ ] One or more NGINX Plus hosts running outside your Kubernetes cluster (NGINX Plus hosts must have the ability to route traffic to the cluster).
 
 There is a more detailed [Installation Reference](docs/README.md) available in the `docs/` directory.


### PR DESCRIPTION

This accommodates the change made in v1.20 which became the standard in 1.24.

This will require users to have Kubernetes v1.24 or higher; while NLK will run on lower versions, the control plane Nodes will not be excluded.

Closes #187 

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CHANGELOG.md))
