### PR TITLE
Corrects the NGINX Plus Client interface

### DIFF
--- a/internal/application/nginx_client_interface.go
+++ b/internal/application/nginx_client_interface.go
@@ -5,19 +5,23 @@
 
 package application
 
-import nginxClient "github.com/nginxinc/nginx-plus-go-client/v2/client"
+import (
+	"context"
+
+	nginxClient "github.com/nginxinc/nginx-plus-go-client/v2/client"
+)
 
 // NginxClientInterface defines the functions used on the NGINX Plus client, abstracting away the full details of that client.
 type NginxClientInterface interface {
 	// DeleteStreamServer is used by the NginxStreamBorderClient.
-	DeleteStreamServer(upstream string, server string) error
+	DeleteStreamServer(ctx context.Context, upstream string, server string) error
 
 	// UpdateStreamServers is used by the NginxStreamBorderClient.
-	UpdateStreamServers(upstream string, servers []nginxClient.StreamUpstreamServer) ([]nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, error)
+	UpdateStreamServers(ctx context.Context, upstream string, servers []nginxClient.StreamUpstreamServer) ([]nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, error)
 
 	// DeleteHTTPServer is used by the NginxHttpBorderClient.
-	DeleteHTTPServer(upstream string, server string) error
+	DeleteHTTPServer(ctx context.Context, upstream string, server string) error
 
 	// UpdateHTTPServers is used by the NginxHttpBorderClient.
-	UpdateHTTPServers(upstream string, servers []nginxClient.UpstreamServer) ([]nginxClient.UpstreamServer, []nginxClient.UpstreamServer, []nginxClient.UpstreamServer, error)
+	UpdateHTTPServers(ctx context.Context, upstream string, servers []nginxClient.UpstreamServer) ([]nginxClient.UpstreamServer, []nginxClient.UpstreamServer, []nginxClient.UpstreamServer, error)
 }

--- a/internal/synchronization/synchronizer_test.go
+++ b/internal/synchronization/synchronizer_test.go
@@ -8,10 +8,11 @@ package synchronization
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/nginxinc/kubernetes-nginx-ingress/internal/configuration"
 	"github.com/nginxinc/kubernetes-nginx-ingress/internal/core"
 	"github.com/nginxinc/kubernetes-nginx-ingress/test/mocks"
-	"testing"
 )
 
 func TestSynchronizer_NewSynchronizer(t *testing.T) {
@@ -183,6 +184,23 @@ func TestSynchronizer_AddEventsManyHosts(t *testing.T) {
 		t.Fatalf(`expected %v events, got %v`, expectedEventCount, actualEventCount)
 	}
 }
+
+//func TestBuildBorderClient(t *testing.T) {
+//	events := buildEvents(1)
+//
+//	settings, err := configuration.NewSettings(context.Background(), nil)
+//	rateLimiter := &mocks.MockRateLimiter{}
+//
+//	synchronizer, err := NewSynchronizer(settings, rateLimiter)
+//	if err != nil {
+//		t.Fatalf(`should have been no error, %v`, err)
+//	}
+//
+//	_, err = synchronizer.buildBorderClient(events[0])
+//	if err != nil {
+//		t.Fatalf(`should have been no error, %v`, err)
+//	}
+//}
 
 func buildEvents(count int) core.ServerUpdateEvents {
 	events := make(core.ServerUpdateEvents, count)

--- a/internal/synchronization/synchronizer_test.go
+++ b/internal/synchronization/synchronizer_test.go
@@ -185,23 +185,6 @@ func TestSynchronizer_AddEventsManyHosts(t *testing.T) {
 	}
 }
 
-//func TestBuildBorderClient(t *testing.T) {
-//	events := buildEvents(1)
-//
-//	settings, err := configuration.NewSettings(context.Background(), nil)
-//	rateLimiter := &mocks.MockRateLimiter{}
-//
-//	synchronizer, err := NewSynchronizer(settings, rateLimiter)
-//	if err != nil {
-//		t.Fatalf(`should have been no error, %v`, err)
-//	}
-//
-//	_, err = synchronizer.buildBorderClient(events[0])
-//	if err != nil {
-//		t.Fatalf(`should have been no error, %v`, err)
-//	}
-//}
-
 func buildEvents(count int) core.ServerUpdateEvents {
 	events := make(core.ServerUpdateEvents, count)
 	for i := 0; i < count; i++ {

--- a/test/mocks/mock_nginx_plus_client.go
+++ b/test/mocks/mock_nginx_plus_client.go
@@ -5,7 +5,11 @@
 
 package mocks
 
-import nginxClient "github.com/nginxinc/nginx-plus-go-client/v2/client"
+import (
+	"context"
+
+	nginxClient "github.com/nginxinc/nginx-plus-go-client/v2/client"
+)
 
 type MockNginxClient struct {
 	CalledFunctions map[string]bool
@@ -26,7 +30,7 @@ func NewErroringMockClient(err error) *MockNginxClient {
 	}
 }
 
-func (m MockNginxClient) DeleteStreamServer(_ string, _ string) error {
+func (m MockNginxClient) DeleteStreamServer(ctx context.Context, string, _ string) error {
 	m.CalledFunctions["DeleteStreamServer"] = true
 
 	if m.Error != nil {
@@ -36,7 +40,7 @@ func (m MockNginxClient) DeleteStreamServer(_ string, _ string) error {
 	return nil
 }
 
-func (m MockNginxClient) UpdateStreamServers(_ string, _ []nginxClient.StreamUpstreamServer) ([]nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, error) {
+func (m MockNginxClient) UpdateStreamServers(ctx context.Context, _ string, _ []nginxClient.StreamUpstreamServer) ([]nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, error) {
 	m.CalledFunctions["UpdateStreamServers"] = true
 
 	if m.Error != nil {
@@ -46,7 +50,7 @@ func (m MockNginxClient) UpdateStreamServers(_ string, _ []nginxClient.StreamUps
 	return nil, nil, nil, nil
 }
 
-func (m MockNginxClient) DeleteHTTPServer(_ string, _ string) error {
+func (m MockNginxClient) DeleteHTTPServer(ctx context.Context, _ string, _ string) error {
 	m.CalledFunctions["DeleteHTTPServer"] = true
 
 	if m.Error != nil {
@@ -56,7 +60,7 @@ func (m MockNginxClient) DeleteHTTPServer(_ string, _ string) error {
 	return nil
 }
 
-func (m MockNginxClient) UpdateHTTPServers(_ string, _ []nginxClient.UpstreamServer) ([]nginxClient.UpstreamServer, []nginxClient.UpstreamServer, []nginxClient.UpstreamServer, error) {
+func (m MockNginxClient) UpdateHTTPServers(ctx context.Context, _ string, _ []nginxClient.UpstreamServer) ([]nginxClient.UpstreamServer, []nginxClient.UpstreamServer, []nginxClient.UpstreamServer, error) {
 	m.CalledFunctions["UpdateHTTPServers"] = true
 
 	if m.Error != nil {


### PR DESCRIPTION
There was a change in the API for the NGINX Plus Client that was missed when updating to the latest version. This corrects that.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-loadbalancer-kubernetes/blob/main/CHANGELOG.md))
